### PR TITLE
Add literature utils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ where = src
 tests =
     pytest
     coverage
+    indra
 docs =
     sphinx
     sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,9 @@ install_requires =
     pyobo
     bioontologies
     biosynonyms
+    pandas
+    tqdm
+    click
 
 # Random options
 zip_safe = false

--- a/src/biolexica/literature/__init__.py
+++ b/src/biolexica/literature/__init__.py
@@ -1,0 +1,19 @@
+"""Tools for working with literature."""
+
+from .annotate import (
+    AnnotatedArticle,
+    Annotation,
+    annotate_abstracts_from_pubmeds,
+    annotate_abstracts_from_search,
+)
+from .retrieve import get_pubmed_dataframe
+from .search import query_pubmed
+
+__all__ = [
+    "query_pubmed",
+    "get_pubmed_dataframe",
+    "AnnotatedArticle",
+    "Annotation",
+    "annotate_abstracts_from_pubmeds",
+    "annotate_abstracts_from_search",
+]

--- a/src/biolexica/literature/__main__.py
+++ b/src/biolexica/literature/__main__.py
@@ -1,0 +1,45 @@
+from tabulate import tabulate
+
+from biolexica import load_grounder
+from biolexica.literature import annotate_abstracts_from_search
+from biolexica.literature.analyze import count_references, count_cooccurrences
+
+import click
+
+
+@click.command()
+@click.option("--query", default="diabetes", help="A query to PubMed")
+@click.option("--grounder", default="phenotype", help="A grounder to load")
+def main(query: str, grounder: str):
+    grounder = load_grounder(grounder)
+
+    click.secho(f"Query for: {query}", fg="green")
+    annotated_articles = annotate_abstracts_from_search(query, grounder=grounder, limit=300)
+
+    reference_counter = count_references(annotated_articles)
+    co_occurrence_counter = count_cooccurrences(annotated_articles)
+
+    click.echo("\nOccurrences")
+    click.echo(
+        tabulate(
+            [(r.curie, name, count) for (r, name), count in reference_counter.most_common(10)],
+            headers=["Reference", "Name", "Count"],
+            tablefmt="github",
+        )
+    )
+
+    click.echo("\nCo-occurrences")
+    click.echo(
+        tabulate(
+            [
+                (l_r.curie, l_n, r_r.curie, r_n, count)
+                for ((l_r, l_n), (r_r, r_n)), count in co_occurrence_counter.most_common(10)
+            ],
+            headers=["Left Reference", "Left Name" "Right Reference", "Right Name", "Count"],
+            tablefmt="github",
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/biolexica/literature/__main__.py
+++ b/src/biolexica/literature/__main__.py
@@ -1,21 +1,17 @@
+"""Demonstrate running search, retrival, annotation, and analysis with recent diabetes literature."""
+
+import click
 from tabulate import tabulate
 
 from biolexica import load_grounder
 from biolexica.literature import annotate_abstracts_from_search
-from biolexica.literature.analyze import count_references, count_cooccurrences
-
-import click
+from biolexica.literature.analyze import count_cooccurrences, count_references
 
 
-@click.command()
-@click.option("--query", default="diabetes", help="A query to PubMed")
-@click.option("--grounder", default="phenotype", help="A grounder to load")
-def main(query: str, grounder: str):
-    grounder = load_grounder(grounder)
-
-    click.secho(f"Query for: {query}", fg="green")
+def _main():
+    query = "diabetes"
+    grounder = load_grounder("phenotype")
     annotated_articles = annotate_abstracts_from_search(query, grounder=grounder, limit=300)
-
     reference_counter = count_references(annotated_articles)
     co_occurrence_counter = count_cooccurrences(annotated_articles)
 
@@ -35,11 +31,11 @@ def main(query: str, grounder: str):
                 (l_r.curie, l_n, r_r.curie, r_n, count)
                 for ((l_r, l_n), (r_r, r_n)), count in co_occurrence_counter.most_common(10)
             ],
-            headers=["Left Reference", "Left Name" "Right Reference", "Right Name", "Count"],
+            headers=["Left Reference", "Left Name", "Right Reference", "Right Name", "Count"],
             tablefmt="github",
         )
     )
 
 
 if __name__ == "__main__":
-    main()
+    _main()

--- a/src/biolexica/literature/analyze.py
+++ b/src/biolexica/literature/analyze.py
@@ -1,13 +1,13 @@
 """Tools for analyzing the results of annotation."""
 
-from collections import Counter
-from operator import attrgetter
-from typing import List
 import typing as t
-
+from collections import Counter
 from itertools import combinations
-from .annotate import AnnotatedArticle
+from typing import List
+
 from curies import Reference
+
+from .annotate import AnnotatedArticle
 
 __all__ = [
     "count_references",

--- a/src/biolexica/literature/analyze.py
+++ b/src/biolexica/literature/analyze.py
@@ -1,0 +1,37 @@
+"""Tools for analyzing the results of annotation."""
+
+from collections import Counter
+from operator import attrgetter
+from typing import List
+import typing as t
+
+from itertools import combinations
+from .annotate import AnnotatedArticle
+from curies import Reference
+
+__all__ = [
+    "count_references",
+    "count_cooccurrences",
+]
+
+
+def count_references(
+    annotated_articles: List[AnnotatedArticle],
+) -> t.Counter[t.Tuple[Reference, str]]:
+    """Count the number of references in the annotated articles."""
+    return Counter(
+        reference_name
+        for annotated_article in annotated_articles
+        for reference_name in annotated_article.count_references()
+    )
+
+
+def count_cooccurrences(
+    annotated_articles: List[AnnotatedArticle],
+) -> t.Counter[t.Tuple[t.Tuple[Reference, str], t.Tuple[Reference, str]]]:
+    """Count the co-occurrences of entities in the annotated articles."""
+    return Counter(
+        tuple(sorted(pair, key=lambda p: p[0].curie))  # type:ignore
+        for annotated_article in annotated_articles
+        for pair in combinations(annotated_article.count_references(), 2)
+    )

--- a/src/biolexica/literature/annotate.py
+++ b/src/biolexica/literature/annotate.py
@@ -66,12 +66,7 @@ def annotate_abstracts_from_search(
     limit: Optional[int] = None,
     **kwargs,
 ) -> List[AnnotatedArticle]:
-    """Get articles based on the query and do NER annotation using the given Gilda grounder.
-
-    Returns a pair of dataframes. The first contains articles recovered by the query with
-    columns ``pubmed``, ``title``, and ``abstract``. The second contains the NER annotations
-    with columns ``pubmed``, ``text``, ``curie``, ``name``, ``start``, and ``end``.
-    """
+    """Get articles based on the query and do NER annotation using the given Gilda grounder."""
     pubmed_ids = query_pubmed(pubmed_query, **kwargs)
     if limit is not None:
         pubmed_ids = pubmed_ids[:limit]
@@ -79,7 +74,7 @@ def annotate_abstracts_from_search(
 
 
 def annotate_abstracts_from_pubmeds(
-    pubmed_ids: List[Union[str, int]],
+    pubmed_ids: t.Collection[Union[str, int]],
     grounder: gilda.Grounder,
     *,
     use_indra_db: bool = True,

--- a/src/biolexica/literature/annotate.py
+++ b/src/biolexica/literature/annotate.py
@@ -1,0 +1,140 @@
+"""Tools for getting literature."""
+
+from __future__ import annotations
+
+import logging
+import time
+import typing as t
+from collections import Counter
+from typing import List, Optional, Union
+
+import gilda
+import gilda.ner
+from curies import Reference
+from more_itertools import batched
+from pydantic import BaseModel
+from tqdm.auto import tqdm
+
+from biolexica.literature.retrieve import get_pubmed_dataframe
+from biolexica.literature.search import query_pubmed
+
+__all__ = [
+    "AnnotatedArticle",
+    "Annotation",
+    "annotate_abstracts_from_search",
+    "annotate_abstracts_from_pubmeds",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+class Annotation(BaseModel):
+    """Data about an annotation."""
+
+    text: str
+    reference: Reference
+    score: float
+    start: int
+    end: int
+    name: str
+
+    @property
+    def substr(self) -> str:
+        """Get the substring that was matched."""
+        return self.text[self.start : self.end]
+
+
+class AnnotatedArticle(BaseModel):
+    """A data model representing an annotated article from PubMed."""
+
+    pubmed: str
+    title: str
+    abstract: str
+    annotations: List[Annotation]
+
+    def count_references(self) -> t.Counter[t.Tuple[Reference, str]]:
+        """Count the references annotated in this article."""
+        return Counter((annotation.reference, annotation.name) for annotation in self.annotations)
+
+
+def annotate_abstracts_from_search(
+    pubmed_query: str,
+    grounder: gilda.Grounder,
+    *,
+    use_indra_db: bool = True,
+    limit: Optional[int] = None,
+    **kwargs,
+) -> List[AnnotatedArticle]:
+    """Get articles based on the query and do NER annotation using the given Gilda grounder.
+
+    Returns a pair of dataframes. The first contains articles recovered by the query with
+    columns ``pubmed``, ``title``, and ``abstract``. The second contains the NER annotations
+    with columns ``pubmed``, ``text``, ``curie``, ``name``, ``start``, and ``end``.
+    """
+    pubmed_ids = query_pubmed(pubmed_query, **kwargs)
+    if limit is not None:
+        pubmed_ids = pubmed_ids[:limit]
+    return annotate_abstracts_from_pubmeds(pubmed_ids, grounder=grounder, use_indra_db=use_indra_db)
+
+
+def annotate_abstracts_from_pubmeds(
+    pubmed_ids: List[Union[str, int]],
+    grounder: gilda.Grounder,
+    *,
+    use_indra_db: bool = True,
+    batch_size: int = 20_000,
+) -> List[AnnotatedArticle]:
+    """Annotate the given articles using the given Gilda grounder."""
+    n_pmids = len(pubmed_ids)
+
+    rv: List[AnnotatedArticle] = []
+
+    outer_it = tqdm(
+        batched(pubmed_ids, batch_size),
+        total=1 + n_pmids // batch_size,
+        unit="batch",
+        desc="Annotating articles",
+    )
+    for i, pubmed_batch in enumerate(outer_it, start=1):
+        t = time.time()
+        pubmed_batch = list(pubmed_batch)
+        articles_df = get_pubmed_dataframe(pubmed_batch, use_indra_db=use_indra_db).reset_index()
+        n_retrieved = len(articles_df.index)
+        tqdm.write(
+            f"[batch {i}] Got {n_retrieved:,} articles "
+            f"({n_retrieved/len(pubmed_batch):.1%}) in {time.time() - t:.2f} seconds"
+        )
+        for pmid, title, abstract in tqdm(
+            articles_df.values,
+            desc=f"Annotating batch {i}",
+            unit_scale=True,
+            unit="article",
+            total=n_retrieved,
+            leave=False,
+        ):
+            rv.append(
+                AnnotatedArticle(
+                    pubmed=pmid,
+                    title=title,
+                    abstract=abstract,
+                    annotations=annotate(abstract, grounder=grounder),
+                )
+            )
+
+    return rv
+
+
+def annotate(text: str, grounder: gilda.Grounder) -> List[Annotation]:
+    """Annotate text using the given Gilda grounder."""
+    return [
+        Annotation(
+            text=text,
+            reference=Reference(prefix=match.term.db, identifier=match.term.id),
+            name=match.term.entry_name,
+            score=match.score,
+            start=start,
+            end=end,
+        )
+        for text, match, start, end in gilda.ner.annotate(text, grounder=grounder)
+    ]

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -99,6 +99,7 @@ def _ensure_db(db=None):
 
 
 def clean_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean the literature dataframe by remove missing titles/abstracts and questionable whitespace."""
     df = df[df.title.notna()].copy()
     df["title"] = df["title"].map(lambda s: s.replace("\n", " ").replace("\t", " "))
     df = df[df.abstract.notna()]

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -1,0 +1,106 @@
+"""Tools for retrieving text content."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Union
+
+import pandas as pd
+from tqdm.asyncio import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+__all__ = [
+    "get_pubmed_dataframe",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def get_pubmed_dataframe(
+    pubmed_ids: Iterable[Union[str, int]], *, use_indra_db: bool = True, db=None
+) -> pd.DataFrame:
+    """Get a dataframe indexed by PubMed identifier (str) with title and abstract columns."""
+    if use_indra_db:
+        try:
+            return _from_indra_db(pubmed_ids, db=db)
+        except ValueError:
+            logger.warning(
+                "Could not to access INDRA DB, relying on PubMed API. "
+                "Warning: this is intractably slow and also is missing full text."
+            )
+    return _from_api(pubmed_ids)
+
+
+def _clean_pubmeds(pubmeds: Iterable[Union[str, int]]) -> List[str]:
+    return sorted(map(str, pubmeds), key=int)
+
+
+def _from_api(pmids: Iterable[Union[str, int]]) -> pd.DataFrame:
+    from indra.literature import pubmed_client
+
+    with logging_redirect_tqdm():
+        rows = [
+            (
+                pmid,
+                pubmed_client.get_title(pmid),
+                pubmed_client.get_abstract(pmid, prepend_title=False),
+            )
+            for pmid in tqdm(
+                _clean_pubmeds(pmids),
+                leave=False,
+                unit_scale=True,
+                unit="article",
+                desc="Getting PubMed titles/abstracts",
+            )
+        ]
+    df = pd.DataFrame(rows, columns=["pubmed", "title", "abstract"]).set_index("pubmed")
+    df = clean_df(df)
+    return df
+
+
+def _from_indra_db(pmids: Iterable[Union[str, int]], db=None) -> pd.DataFrame:
+    """Get titles and abstracts from the INDRA database."""
+    db = _ensure_db(db)
+    pmids = _clean_pubmeds(pmids)
+    df = pd.DataFrame(
+        {
+            "title": _get_text(pmids, text_type="title", db=db),
+            "abstract": _get_text(pmids, text_type="abstract", db=db),
+        }
+    )
+    df.index.name = "pubmed"
+    df = clean_df(df)
+    return df
+
+
+def _get_text(pmids: List[str], text_type: str, db) -> Dict[str, str]:
+    from indra_db.util.helpers import unpack as unpack_indra_db
+
+    return {
+        row.pmid: unpack_indra_db(row.content).replace("\t", " ").replace("\n", "\t")
+        for row in (
+            db.session.query(db.TextRef.pmid, db.TextContent.text_type, db.TextContent.content)
+            .filter(db.TextRef.pmid_in(pmids))
+            .join(db.TextContent)
+            .filter(db.TextContent.text_type == text_type)
+            .all()
+        )
+    }
+
+
+def _ensure_db(db=None):
+    from indra_db import get_db
+
+    if db is None:
+        db = get_db("primary")
+    if db is None:
+        raise ValueError("Could not connect to INDRA DB")
+    return db
+
+
+def clean_df(df: pd.DataFrame) -> pd.DataFrame:
+    df = df[df.title.notna()].copy()
+    df["title"] = df["title"].map(lambda s: s.replace("\n", " ").replace("\t", " "))
+    df = df[df.abstract.notna()]
+    df["abstract"] = df["abstract"].map(lambda s: s.replace("\n", " ").replace("\t", " "))
+    return df

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -23,7 +23,7 @@ def get_pubmed_dataframe(
     if use_indra_db:
         try:
             return _from_indra_db(pubmed_ids, db=db)
-        except ValueError:
+        except (ValueError, ImportError):
             logger.warning(
                 "Could not to access INDRA DB, relying on PubMed API. "
                 "Warning: this is intractably slow and also is missing full text."

--- a/src/biolexica/literature/search.py
+++ b/src/biolexica/literature/search.py
@@ -1,0 +1,47 @@
+"""Tools for searching PubMed."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, List, Literal, Optional
+
+__all__ = [
+    "query_pubmed",
+]
+
+
+def query_pubmed(
+    search_term: str,
+    *,
+    method: Optional[Literal["api", "esearch"]] = None,
+    **kwargs: Any,
+) -> List[str]:
+    """Query PubMed for article identifiers based on a given search."""
+    if method == "esearch":
+        return _get_pmids_with_esearch(search_term)
+    elif method is None or method == "api":
+        return _get_pmids_with_indra(search_term, **kwargs)
+    raise ValueError(f"Unknown method: {method}")
+
+
+def _get_pmids_with_indra(search_term: str, **kwargs: Any) -> List[str]:
+    from indra.literature import pubmed_client
+
+    return pubmed_client.get_ids(search_term, **kwargs)
+
+
+def _get_pmids_with_esearch(search_term: str) -> List[str]:
+    #  TODO replace with https://github.com/sorgerlab/indra/pull/1424/files
+    injection = "PATH=/Users/cthoyt/edirect:${PATH}"
+    cmd = f'{injection} esearch -db pubmed -query "{search_term}" | {injection} efetch -format uid'
+    res = subprocess.getoutput(cmd)
+    if "esearch: command not found" in res:
+        raise RuntimeError("esearch is not properly on the filepath")
+    if "efetch: command not found" in res:
+        raise RuntimeError("efetch is not properly on the filepath")
+    # Output is divided by new lines
+    elements = res.split("\n")
+    # If there are more than 10k IDs, the CLI outputs a . for each
+    # iteration, these have to be filtered out
+    pmids = [e for e in elements if "." not in e]
+    return pmids

--- a/tests/test_lexica.py
+++ b/tests/test_lexica.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import biolexica
 from biolexica.api import PREDEFINED
+from biolexica.literature import annotate_abstracts_from_search
 
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent
@@ -22,7 +23,7 @@ class TestLexica(unittest.TestCase):
         """Set up the class with several grounders."""
         cls.cell_grounder = biolexica.load_grounder(CELL_TERMS)
         # cls.anatomy_grounder = biolexica.load_grounder(ANATOMY_TERMS)
-        # cls.phenotype_grounder = biolexica.load_grounder(PHENOTYPE_TERMS)
+        cls.phenotype_grounder = biolexica.load_grounder(PHENOTYPE_TERMS)
 
     def test_predefined_list(self):
         """Check the predefined list is right."""
@@ -35,3 +36,16 @@ class TestLexica(unittest.TestCase):
         self.assertEqual(1, len(res))
         self.assertEqual("cellosaurus", res[0].term.db)
         self.assertEqual("0030", res[0].term.id)
+
+    def test_search_alz(self):
+        """Test searching and annotating Alzheimer's docs gets a desired annotation."""
+        results = annotate_abstracts_from_search(
+            "alzheimers", grounder=self.phenotype_grounder, limit=20
+        )
+        self.assertTrue(
+            any(
+                ref.curie == "doid:10652"  # this is the DOID term for Alzheimer's disease
+                for result in results
+                for ref, _name in result.count_references()
+            )
+        )

--- a/tests/test_lexica.py
+++ b/tests/test_lexica.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 import biolexica
+from biolexica.api import PREDEFINED
 
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent
@@ -22,6 +23,10 @@ class TestLexica(unittest.TestCase):
         cls.cell_grounder = biolexica.load_grounder(CELL_TERMS)
         # cls.anatomy_grounder = biolexica.load_grounder(ANATOMY_TERMS)
         # cls.phenotype_grounder = biolexica.load_grounder(PHENOTYPE_TERMS)
+
+    def test_predefined_list(self):
+        """Check the predefined list is right."""
+        self.assertEqual(set(PREDEFINED), {d.name for d in LEXICA.iterdir() if d.is_dir()})
 
     def test_ground_cells(self):
         """Test grounding cells."""

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,14 @@ envlist =
 # Runs on the "tests" directory by default, or passes the positional
 # arguments from `tox -e py <posargs_1> ... <posargs_n>
 commands =
+    python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
 extras =
     # See the [options.extras_require] entry in setup.cfg for "tests"
     tests
-    
+
 [testenv:doctests]
 description = Test that documentation examples run properly
 commands =


### PR DESCRIPTION
This PR adds a workflow for searching literature, retrieving abstracts, annotating them, and summarizing the results. 

Specifically, it's a demo of how you can quickly re-use the pre-defined lexica. For example, querying for diabetes (limited to 300 recent articles) and grounding using the `phenotype` lexicon in the following code gives:

```python
from biolexica import load_grounder
from biolexica.literature import annotate_abstracts_from_search
from biolexica.literature.analyze import count_cooccurrences, count_references

query = "diabetes"
grounder = load_grounder("phenotype")
annotated_articles = annotate_abstracts_from_search(query, grounder=grounder, limit=300)

# Analysis
reference_counter = count_references(annotated_articles)
co_occurrence_counter = count_cooccurrences(annotated_articles)
```

Occurrences
| Reference     | Name                     |   Count |
|---------------|--------------------------|---------|
| doid:9351     | diabetes mellitus        |      95 |
| doid:9352     | type 2 diabetes mellitus |      54 |
| mesh:D013812  | treatment                |      52 |
| doid:4        | disease                  |      49 |
| mesh:D012380  | Role                     |      31 |
| efo:0001461   | control                  |      29 |
| efo:0000246   | age                      |      28 |
| mesh:D001244  | Association              |      26 |
| mondo:0021137 | not rare                 |      25 |
| efo:0003919   | risk factor              |      24 |

Co-occurrences
| Left Reference           | Left Name | Right Reference   | Right Name               |   Count |
|-----------|--------------------------|----------------------------|--------------------------|---------|
| doid:9351 | diabetes mellitus        | mesh:D013812               | treatment                |      32 |
| doid:4    | disease                  | doid:9351                  | diabetes mellitus        |      31 |
| doid:9351 | diabetes mellitus        | doid:9352                  | type 2 diabetes mellitus |      21 |
| doid:4    | disease                  | mesh:D013812               | treatment                |      20 |
| doid:9351 | diabetes mellitus        | mondo:0021137              | not rare                 |      18 |
| doid:9351 | diabetes mellitus        | mesh:D012380               | Role                     |      17 |
| doid:9352 | type 2 diabetes mellitus | efo:0000246                | age                      |      16 |
| doid:9352 | type 2 diabetes mellitus | efo:0001461                | control                  |      16 |
| doid:9351 | diabetes mellitus        | efo:0003919                | risk factor              |      16 |
| doid:4    | disease                  | doid:9352                  | type 2 diabetes mellitus |      15 |

A few things that are immediately obvious:

1. Need some notion of exclude lists in the lexica construction to remove frequently occurring, but not specific entities like "Disease" and "Role"