### PR TITLE
Enable configuring exclusions from indexing

### DIFF
--- a/lexica/anatomy/generate.py
+++ b/lexica/anatomy/generate.py
@@ -15,24 +15,26 @@ PRIORITY = [
     "ncit",
     # "umls", # TODO find appropriate subset
 ]
-BIOLEXICA_CONFIG = [
-    biolexica.Input(source="uberon", processor="pyobo"),
-    biolexica.Input(
-        source="mesh",
-        # skip A11 since it's cells
-        ancestors=biolexica.get_mesh_category_curies("A", skip=["A11"]),
-        processor="pyobo",
-    ),
-    biolexica.Input(
-        source="ncit",
-        ancestors=[
-            "NCIT:C12219",  # Anatomic Structure, System, or Substance
-        ],
-        processor="pyobo",
-    ),
-    biolexica.Input(source="bto", processor="pyobo"),
-    biolexica.Input(source="caro", processor="pyobo"),
-]
+BIOLEXICA_CONFIG = biolexica.Configuration(
+    inputs=[
+        biolexica.Input(source="uberon", processor="pyobo"),
+        biolexica.Input(
+            source="mesh",
+            # skip A11 since it's cells
+            ancestors=biolexica.get_mesh_category_curies("A", skip=["A11"]),
+            processor="pyobo",
+        ),
+        biolexica.Input(
+            source="ncit",
+            ancestors=[
+                "NCIT:C12219",  # Anatomic Structure, System, or Substance
+            ],
+            processor="pyobo",
+        ),
+        biolexica.Input(source="bto", processor="pyobo"),
+        biolexica.Input(source="caro", processor="pyobo"),
+    ]
+)
 
 SEMRA_CONFIG = semra.Configuration(
     name="Anatomy mappings",
@@ -66,7 +68,7 @@ SEMRA_CONFIG = semra.Configuration(
 def _main() -> None:
     mappings = SEMRA_CONFIG.get_mappings()
     biolexica.assemble_terms(
-        inputs=BIOLEXICA_CONFIG,
+        BIOLEXICA_CONFIG,
         mappings=mappings,
         processed_path=TERMS_PATH,
     )

--- a/lexica/cell/generate.py
+++ b/lexica/cell/generate.py
@@ -8,15 +8,19 @@ HERE = Path(__file__).parent.resolve()
 TERMS_PATH = HERE.joinpath("terms.tsv.gz")
 
 PRIORITY = ["cl", "cellosaurus", "bto", "clo", "efo", "mesh", "ccle", "depmap"]
-BIOLEXICA_CONFIG = [
-    biolexica.Input(source="mesh", processor="pyobo", ancestors=["mesh:D002477"]),  # cells (A11)
-    biolexica.Input(source="efo", processor="pyobo", ancestors=["efo:0000324"]),
-    biolexica.Input(source="cellosaurus", processor="pyobo"),
-    biolexica.Input(source="ccle", processor="pyobo"),
-    biolexica.Input(source="bto", processor="pyobo"),
-    biolexica.Input(source="cl", processor="pyobo"),
-    biolexica.Input(source="clo", processor="pyobo"),
-]
+BIOLEXICA_CONFIG = biolexica.Configuration(
+    inputs=[
+        biolexica.Input(
+            source="mesh", processor="pyobo", ancestors=["mesh:D002477"]
+        ),  # cells (A11)
+        biolexica.Input(source="efo", processor="pyobo", ancestors=["efo:0000324"]),
+        biolexica.Input(source="cellosaurus", processor="pyobo"),
+        biolexica.Input(source="ccle", processor="pyobo"),
+        biolexica.Input(source="bto", processor="pyobo"),
+        biolexica.Input(source="cl", processor="pyobo"),
+        biolexica.Input(source="clo", processor="pyobo"),
+    ]
+)
 
 SEMRA_CONFIG = semra.Configuration(
     name="Cell and Cell Line Mappings",
@@ -66,7 +70,7 @@ SEMRA_CONFIG = semra.Configuration(
 def _main() -> None:
     mappings = SEMRA_CONFIG.get_mappings()
     biolexica.assemble_terms(
-        inputs=BIOLEXICA_CONFIG,
+        BIOLEXICA_CONFIG,
         mappings=mappings,
         processed_path=TERMS_PATH,
     )

--- a/lexica/phenotype/generate.py
+++ b/lexica/phenotype/generate.py
@@ -34,7 +34,7 @@ BIOLEXICA_CONFIG = biolexica.Configuration(
         # biolexica.Input(source="umls", processor="pyobo"), # TODO find subset of UMLS
         # biolexica.Input(source="ncit", processor="pyobo"), # TODO find subset of NCIT
     ],
-    exclude=["doid:4"],
+    excludes=["doid:4"],
 )
 
 SEMRA_CONFIG = semra.Configuration(

--- a/lexica/phenotype/generate.py
+++ b/lexica/phenotype/generate.py
@@ -15,24 +15,27 @@ PRIORITY = [
     "mesh",
     "efo",
 ]
-BIOLEXICA_CONFIG = [
-    biolexica.Input(source="doid", processor="pyobo"),
-    biolexica.Input(source="mondo", processor="pyobo"),
-    biolexica.Input(source="hp", processor="pyobo"),
-    biolexica.Input(source="symp", processor="pyobo"),
-    biolexica.Input(
-        source="mesh",
-        processor="pyobo",
-        ancestors=[
-            *biolexica.get_mesh_category_curies("C"),
-            *biolexica.get_mesh_category_curies("F"),
-            # TODO should there be others?
-        ],
-    ),
-    biolexica.Input(source="efo", processor="pyobo"),  # TODO find subset of EFO
-    # biolexica.Input(source="umls", processor="pyobo"), # TODO find subset of UMLS
-    # biolexica.Input(source="ncit", processor="pyobo"), # TODO find subset of NCIT
-]
+BIOLEXICA_CONFIG = biolexica.Configuration(
+    inputs=[
+        biolexica.Input(source="doid", processor="pyobo"),
+        biolexica.Input(source="mondo", processor="pyobo"),
+        biolexica.Input(source="hp", processor="pyobo"),
+        biolexica.Input(source="symp", processor="pyobo"),
+        biolexica.Input(
+            source="mesh",
+            processor="pyobo",
+            ancestors=[
+                *biolexica.get_mesh_category_curies("C"),
+                *biolexica.get_mesh_category_curies("F"),
+                # TODO should there be others?
+            ],
+        ),
+        biolexica.Input(source="efo", processor="pyobo"),  # TODO find subset of EFO
+        # biolexica.Input(source="umls", processor="pyobo"), # TODO find subset of UMLS
+        # biolexica.Input(source="ncit", processor="pyobo"), # TODO find subset of NCIT
+    ],
+    exclude=["doid:4"],
+)
 
 SEMRA_CONFIG = semra.Configuration(
     name="Cell and Cell Line Mappings",
@@ -68,7 +71,7 @@ SEMRA_CONFIG = semra.Configuration(
 def _main() -> None:
     mappings = SEMRA_CONFIG.get_mappings()
     biolexica.assemble_terms(
-        inputs=BIOLEXICA_CONFIG,
+        BIOLEXICA_CONFIG,
         mappings=mappings,
         processed_path=TERMS_PATH,
     )

--- a/src/biolexica/api.py
+++ b/src/biolexica/api.py
@@ -44,6 +44,8 @@ class Input(BaseModel):
 
 
 class Configuration(BaseModel):
+    """A configuration for construction of a lexicon."""
+
     inputs: List[Input]
     excludes: Optional[List[str]] = None
     raw_path: Optional[Path] = None

--- a/src/biolexica/api.py
+++ b/src/biolexica/api.py
@@ -12,7 +12,7 @@ import gilda
 import pyobo
 from gilda.grounder import load_entries_from_terms_file
 from gilda.process import normalize
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
@@ -47,9 +47,9 @@ class Configuration(BaseModel):
     """A configuration for construction of a lexicon."""
 
     inputs: List[Input]
-    excludes: Optional[List[str]] = None
-    raw_path: Optional[Path] = None
-    processed_path: Optional[Path] = None
+    excludes: Optional[List[str]] = Field(
+        default=None, description="A list of CURIEs to exclude after processing is complete"
+    )
 
 
 PREDEFINED = ["cell", "anatomy", "phenotype"]

--- a/src/biolexica/literature/annotate.py
+++ b/src/biolexica/literature/annotate.py
@@ -64,13 +64,16 @@ def annotate_abstracts_from_search(
     *,
     use_indra_db: bool = True,
     limit: Optional[int] = None,
+    show_progress: bool = True,
     **kwargs,
 ) -> List[AnnotatedArticle]:
     """Get articles based on the query and do NER annotation using the given Gilda grounder."""
     pubmed_ids = query_pubmed(pubmed_query, **kwargs)
     if limit is not None:
         pubmed_ids = pubmed_ids[:limit]
-    return annotate_abstracts_from_pubmeds(pubmed_ids, grounder=grounder, use_indra_db=use_indra_db)
+    return annotate_abstracts_from_pubmeds(
+        pubmed_ids, grounder=grounder, use_indra_db=use_indra_db, show_progress=show_progress
+    )
 
 
 def annotate_abstracts_from_pubmeds(
@@ -79,6 +82,7 @@ def annotate_abstracts_from_pubmeds(
     *,
     use_indra_db: bool = True,
     batch_size: int = 20_000,
+    show_progress: bool = True,
 ) -> List[AnnotatedArticle]:
     """Annotate the given articles using the given Gilda grounder."""
     n_pmids = len(pubmed_ids)
@@ -90,6 +94,7 @@ def annotate_abstracts_from_pubmeds(
         total=1 + n_pmids // batch_size,
         unit="batch",
         desc="Annotating articles",
+        disable=not show_progress,
     )
     for i, pubmed_batch in enumerate(outer_it, start=1):
         t = time.time()
@@ -107,6 +112,7 @@ def annotate_abstracts_from_pubmeds(
             unit="article",
             total=n_retrieved,
             leave=False,
+            disable=not show_progress,
         ):
             rv.append(
                 AnnotatedArticle(

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -26,7 +26,7 @@ def get_pubmed_dataframe(
         except (ValueError, ImportError):
             logger.warning(
                 "Could not to access INDRA DB, relying on PubMed API. "
-                "Warning: this is intractably slow and also is missing full text."
+                "Warning: this could be intractably slow depending on the query, and also is missing full text."
             )
     return _from_api(pubmed_ids)
 

--- a/tests/test_lexica.py
+++ b/tests/test_lexica.py
@@ -49,3 +49,10 @@ class TestLexica(unittest.TestCase):
                 for ref, _name in result.count_references()
             )
         )
+        self.assertFalse(
+            any(
+                ref.curie == "doid:4"  # this is the DOID term for disease, should be filtered out
+                for result in results
+                for ref, _name in result.count_references()
+            )
+        )

--- a/tests/test_lexica.py
+++ b/tests/test_lexica.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import biolexica
 from biolexica.api import PREDEFINED
-from biolexica.literature import annotate_abstracts_from_search, annotate_abstracts_from_pubmeds
+from biolexica.literature import annotate_abstracts_from_pubmeds, annotate_abstracts_from_search
 
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent

--- a/tests/test_lexica.py
+++ b/tests/test_lexica.py
@@ -49,10 +49,16 @@ class TestLexica(unittest.TestCase):
                 for ref, _name in result.count_references()
             )
         )
-        self.assertFalse(
-            any(
-                ref.curie == "doid:4"  # this is the DOID term for disease, should be filtered out
-                for result in results
-                for ref, _name in result.count_references()
-            )
+
+        articles_with_doid_4 = {
+            result.pubmed
+            for result in results
+            for ref, _name in result.count_references()
+            if ref.curie == "doid:4"
+        }
+        self.assertEqual(
+            set(),
+            articles_with_doid_4,
+            msg="No articles should contain the reference `doid:4` for the top-level disease annotation, "
+            "since this should be filtered out during construction of the lexical index.",
         )


### PR DESCRIPTION
1. This makes the configuration a declarative object
2. This adds global exclusion, which should get applied after processing
3. The first example is to remove `doid:4` (disease) from the disease build, since this is super frequent, but not one we want to recognize on its own. Conversely, this might be an interesting tool for identifying disease names that should be included in Biosynonyms or put into a disease ontology