### PR TITLE
Change API for getting article dataframes and add pretoken analysis

### DIFF
--- a/src/biolexica/literature/__init__.py
+++ b/src/biolexica/literature/__init__.py
@@ -6,12 +6,13 @@ from .annotate import (
     annotate_abstracts_from_pubmeds,
     annotate_abstracts_from_search,
 )
-from .retrieve import get_pubmed_dataframe
-from .search import query_pubmed
+from .retrieve import get_article_dataframe_from_pubmeds
+from .search import get_article_dataframe_from_search, query_pubmed
 
 __all__ = [
     "query_pubmed",
-    "get_pubmed_dataframe",
+    "get_article_dataframe_from_pubmeds",
+    "get_article_dataframe_from_search",
     "AnnotatedArticle",
     "Annotation",
     "annotate_abstracts_from_pubmeds",

--- a/src/biolexica/literature/annotate.py
+++ b/src/biolexica/literature/annotate.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 import logging
-import time
 import typing as t
 from collections import Counter
 from typing import List, Optional, Union
 
 from curies import Reference
-from more_itertools import batched
 from pydantic import BaseModel
 from tqdm.auto import tqdm
 
 from biolexica.api import Annotation, GrounderHint, load_grounder
-from biolexica.literature.retrieve import get_pubmed_dataframe
+from biolexica.literature.retrieve import _iter_dataframes_from_pubmeds
 from biolexica.literature.search import query_pubmed
 
 __all__ = [
@@ -63,48 +61,33 @@ def annotate_abstracts_from_pubmeds(
     grounder: GrounderHint,
     *,
     use_indra_db: bool = True,
-    batch_size: int = 20_000,
+    batch_size: Optional[int] = None,
     show_progress: bool = True,
 ) -> List[AnnotatedArticle]:
     """Annotate the given articles using the given Gilda grounder."""
-    n_pmids = len(pubmed_ids)
-
-    rv: List[AnnotatedArticle] = []
-
     grounder = load_grounder(grounder)
-
-    outer_it = tqdm(
-        batched(pubmed_ids, batch_size),
-        total=1 + n_pmids // batch_size,
-        unit="batch",
-        desc="Annotating articles",
-        disable=not show_progress,
+    df_iterator = _iter_dataframes_from_pubmeds(
+        pubmed_ids=pubmed_ids,
+        batch_size=batch_size,
+        use_indra_db=use_indra_db,
+        show_progress=show_progress,
     )
-    for i, pubmed_batch in enumerate(outer_it, start=1):
-        t = time.time()
-        pubmed_batch = list(pubmed_batch)
-        articles_df = get_pubmed_dataframe(pubmed_batch, use_indra_db=use_indra_db).reset_index()
-        n_retrieved = len(articles_df.index)
-        tqdm.write(
-            f"[batch {i}] Got {n_retrieved:,} articles "
-            f"({n_retrieved/len(pubmed_batch):.1%}) in {time.time() - t:.2f} seconds"
+    rv: List[AnnotatedArticle] = [
+        AnnotatedArticle(
+            pubmed=pubmed,
+            title=title,
+            abstract=abstract,
+            annotations=grounder.annotate(abstract),
         )
-        for pmid, title, abstract in tqdm(
-            articles_df.values,
+        for i, df in enumerate(df_iterator, start=1)
+        for pubmed, title, abstract in tqdm(
+            df.values,
             desc=f"Annotating batch {i}",
             unit_scale=True,
             unit="article",
-            total=n_retrieved,
+            total=len(df.index),
             leave=False,
             disable=not show_progress,
-        ):
-            rv.append(
-                AnnotatedArticle(
-                    pubmed=pmid,
-                    title=title,
-                    abstract=abstract,
-                    annotations=grounder.annotate(abstract),
-                )
-            )
-
+        )
+    ]
     return rv

--- a/src/biolexica/literature/annotate.py
+++ b/src/biolexica/literature/annotate.py
@@ -81,7 +81,7 @@ def annotate_abstracts_from_pubmeds(
         )
         for i, df in enumerate(df_iterator, start=1)
         for pubmed, title, abstract in tqdm(
-            df.values,
+            df.itertuples(),
             desc=f"Annotating batch {i}",
             unit_scale=True,
             unit="article",

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterable, List, Union
+import time
+from typing import Dict, Iterable, List, Optional, Union
 
 import pandas as pd
+from more_itertools import batched
 from tqdm.asyncio import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 __all__ = [
-    "get_pubmed_dataframe",
+    "get_article_dataframe_from_pubmeds",
     "PUBMED_DATAFRAME_COLUMNS",
     "clean_df",
 ]
@@ -21,10 +23,27 @@ logger = logging.getLogger(__name__)
 PUBMED_DATAFRAME_COLUMNS = ["pubmed", "title", "abstract"]
 
 
-def get_pubmed_dataframe(
-    pubmed_ids: Iterable[Union[str, int]], *, use_indra_db: bool = True, db=None
+def get_article_dataframe_from_pubmeds(
+    pubmed_ids: Iterable[Union[str, int]],
+    *,
+    use_indra_db: bool = True,
+    db=None,
+    batch_size: Optional[int] = None,
+    show_progress: bool = True,
 ) -> pd.DataFrame:
     """Get a dataframe indexed by PubMed identifier (str) with title and abstract columns."""
+    return pd.concat(
+        _iter_dataframes_from_pubmeds(
+            pubmed_ids=pubmed_ids,
+            use_indra_db=use_indra_db,
+            db=db,
+            batch_size=batch_size,
+            show_progress=show_progress,
+        )
+    )
+
+
+def _get_batch(pubmed_ids: Iterable[Union[str, int]], *, use_indra_db: bool = True, db=None):
     if use_indra_db:
         try:
             return _from_indra_db(pubmed_ids, db=db)
@@ -34,6 +53,45 @@ def get_pubmed_dataframe(
                 "Warning: this could be intractably slow depending on the query, and also is missing full text."
             )
     return _from_api(pubmed_ids)
+
+
+def _iter_dataframes_from_pubmeds(
+    pubmed_ids: Iterable[Union[str, int]],
+    *,
+    use_indra_db: bool = True,
+    db=None,
+    batch_size: Optional[int] = None,
+    show_progress: bool = True,
+) -> Iterable[pd.DataFrame]:
+    """Query PubMed for article identifiers based on a given search and get a dataframe."""
+    if batch_size is None:
+        batch_size = 20_000
+
+    pubmed_ids = _clean_pubmeds(pubmed_ids)
+    if len(pubmed_ids) < batch_size:
+        # only a single batch, iterator not needed
+        show_progress = False
+    outer_it = tqdm(
+        batched(pubmed_ids, batch_size),
+        total=1 + len(pubmed_ids) // batch_size,
+        unit="batch",
+        desc="Getting articles",
+        disable=not show_progress,
+    )
+    for i, pubmed_batch in enumerate(outer_it, start=1):
+        pubmed_batch = list(pubmed_batch)
+        t = time.time()
+        df = _get_batch(
+            pubmed_batch,
+            use_indra_db=use_indra_db,
+            db=db,
+        )
+        n_retrieved = len(df.index)
+        outer_it.write(
+            f"[batch {i}] Got {n_retrieved:,} articles "
+            f"({n_retrieved/len(pubmed_batch):.1%}) in {time.time() - t:.2f} seconds"
+        )
+        yield df
 
 
 def _clean_pubmeds(pubmeds: Iterable[Union[str, int]]) -> List[str]:

--- a/src/biolexica/literature/retrieve.py
+++ b/src/biolexica/literature/retrieve.py
@@ -81,11 +81,7 @@ def _iter_dataframes_from_pubmeds(
     for i, pubmed_batch in enumerate(outer_it, start=1):
         pubmed_batch = list(pubmed_batch)
         t = time.time()
-        df = _get_batch(
-            pubmed_batch,
-            use_indra_db=use_indra_db,
-            db=db,
-        )
+        df = _get_batch(pubmed_batch, use_indra_db=use_indra_db, db=db)
         n_retrieved = len(df.index)
         outer_it.write(
             f"[batch {i}] Got {n_retrieved:,} articles "
@@ -116,7 +112,8 @@ def _from_api(pmids: Iterable[Union[str, int]]) -> pd.DataFrame:
                 desc="Getting PubMed titles/abstracts",
             )
         ]
-    df = pd.DataFrame(rows, columns=PUBMED_DATAFRAME_COLUMNS).set_index("pubmed")
+    df = pd.DataFrame(rows, columns=PUBMED_DATAFRAME_COLUMNS)
+    df = df.set_index("pubmed")
     df = clean_df(df)
     return df
 

--- a/src/biolexica/literature/search.py
+++ b/src/biolexica/literature/search.py
@@ -5,15 +5,46 @@ from __future__ import annotations
 import subprocess
 from typing import Any, List, Literal, Optional
 
+import pandas as pd
+
+from .retrieve import get_article_dataframe_from_pubmeds
+
 __all__ = [
+    "get_article_dataframe_from_search",
     "query_pubmed",
 ]
+
+Method = Literal["api", "esearch"]
+
+
+def get_article_dataframe_from_search(
+    search_term: str,
+    *,
+    method: Optional[Method] = None,
+    use_indra_db: bool = True,
+    db=None,
+    batch_size: Optional[int] = None,
+    show_progress: bool = True,
+    limit: Optional[int] = None,
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Query PubMed for article identifiers based on a given search and get a dataframe."""
+    pubmed_ids = query_pubmed(search_term, method=method, **kwargs)
+    if limit:
+        pubmed_ids = pubmed_ids[:limit]
+    return get_article_dataframe_from_pubmeds(
+        pubmed_ids,
+        use_indra_db=use_indra_db,
+        db=db,
+        batch_size=batch_size,
+        show_progress=show_progress,
+    )
 
 
 def query_pubmed(
     search_term: str,
     *,
-    method: Optional[Literal["api", "esearch"]] = None,
+    method: Optional[Method] = None,
     **kwargs: Any,
 ) -> List[str]:
     """Query PubMed for article identifiers based on a given search."""


### PR DESCRIPTION
This PR does the following

1. renames `biolexica.literature.get_pubmed_dataframe` to `biolexica.literature.get_article_dataframe_from_pubmeds` (breaking change)
2. makes batching part of this process from default
3. adds `biolexica.literature.get_article_dataframe_from_search`
4. adds pre-word analysis and example